### PR TITLE
Fix: Bundlerのバージョンを2.5.6に指定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
 
 # Rubyの依存関係をインストールします。
 COPY Gemfile Gemfile.lock ./
+RUN gem install bundler:2.5.6
 RUN bundle install
 RUN rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 RUN bundle exec bootsnap precompile --gemfile

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,7 +20,7 @@ RUN npm install -g yarn
 
 # GemfileとGemfile.lockをコピーし、Bundlerと依存関係をインストール
 COPY Gemfile Gemfile.lock ./
-RUN gem install bundler:2.5.7 && \
+RUN gem install bundler:2.5.6 && \
     bundle install --binstubs
 
 # Yarnの依存関係をインストール

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,8 +138,6 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
-    nokogiri (1.16.3-aarch64-linux)
-      racc (~> 1.4)
     nokogiri (1.16.3-arm64-darwin)
       racc (~> 1.4)
     parallel (1.24.0)
@@ -264,7 +262,6 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  aarch64-linux
   arm64-darwin-23
 
 DEPENDENCIES


### PR DESCRIPTION
ビルドプロセスにおいて、Gemfile.lockが生成された同じバージョンのBundlerを使用することを保証するため、DockerfileにRUN gem install bundler:2.5.6を追加しました。

これにより、依存関係の解決に関する問題を防ぐことが期待されます。